### PR TITLE
Add rest_framework to settings.py backend

### DIFF
--- a/manager/manager/settings.py
+++ b/manager/manager/settings.py
@@ -44,6 +44,7 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'rest_framework',
     'users',
     'wins',
 ]


### PR DESCRIPTION
Add rest_framework to settings.py backend in order to fetch APIs.